### PR TITLE
Inline mode fix

### DIFF
--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -843,8 +843,7 @@ class ChatGPTTelegramBot:
                 title=localized_text("ask_chatgpt", bot_language),
                 input_message_content=InputTextMessageContent(message_content),
                 description=message_content,
-                thumb_url='https://user-images.githubusercontent.com/11541888/223106202-7576ff11-2c8e-408d-94ea'
-                          '-b02a7a32149a.png',
+                thumbnail_url='https://user-images.githubusercontent.com/11541888/223106202-7576ff11-2c8e-408d-94ea-b02a7a32149a.png',
                 reply_markup=reply_markup
             )
 


### PR DESCRIPTION
Fixing 
"ERROR - An error occurred while generating the result card for inline query init () got an unexpected keyword argument 'thumb_url'"  error by 
1. editing broken thumb url
2. changing thumb_url to thumbnail_url wrong parameter name